### PR TITLE
Add thermostat setting action flow card

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,7 +17,6 @@ class NibeApp extends OAuth2App {
 			authorizationUrl: `${NibeOAuth2Client.API_URL}/oauth/authorize`,
 			scopes: ['READSYSTEM', 'WRITESYSTEM'],
 		});
-
 	}
 }
 

--- a/app.json
+++ b/app.json
@@ -565,6 +565,55 @@
             "filter": "driver_id=nibe"
           }
         ]
+      },
+      {
+        "id": "update_thermostat",
+        "title": {
+          "en": "Set temperature setting",
+          "sv": "Sätt tempraturinställningar"
+        },
+        "args": [
+          {
+            "type": "autocomplete",
+            "name": "climate_system",
+            "placeholder": {
+              "en": "Select one climate system",
+              "sv": "Välj ett klimatsystem"
+            }
+          },
+          {
+            "name": "thermostat_name",
+            "type": "text",
+            "label": "Thermostat name",
+            "placeholder": {
+              "en": "Name of thermostat",
+              "sv": "Namn på termostat"
+            }
+          },
+          {
+            "name": "target_temperature",
+            "type": "range",
+            "min": 5,
+            "max": 40,
+            "step": 0.1,
+            "label": "°C (target temp)",
+            "labelDecimals": 1
+          },
+          {
+            "name": "measured_temperature",
+            "type": "range",
+            "min": 5,
+            "max": 40,
+            "step": 0.1,
+            "label": "°C (measured temp)",
+            "labelDecimals": 1
+          },
+          {
+            "name": "nibe",
+            "type": "device",
+            "filter": "driver_id=nibe"
+          }
+        ]
       }
     ]
   }

--- a/lib/NibeOAuth2Client.js
+++ b/lib/NibeOAuth2Client.js
@@ -56,11 +56,35 @@ class NibeOAuth2Client extends OAuth2Client {
         })
     }
 
+    async getSmartHomeThermostats(id) {
+        return this.get({
+            path: `/api/v1/systems/${id}/smarthome/thermostats`
+        })
+    }
+
     async putParameters(id, settings) {
         return this.put({
             path: `/api/v1/systems/${id}`,
             body: {
               "settings": settings
+            }
+        })
+    }
+
+    async postSmartHomeThermostats(id,
+                                   thermostat_id,
+                                   thermostat_name,
+                                   measured_temp,
+                                   target_temp,
+                                   climate_systems) {
+        return this.post({
+            path: `/api/v1/systems/${id}/smarthome/thermostats`,
+            json: {
+                "externalId": thermostat_id,
+                "name": thermostat_name,
+                "actualTemp": measured_temp*10,
+                "targetTemp": target_temp*10,
+                "climateSystems": [climate_systems.charAt(climate_systems.length-1)]
             }
         })
     }


### PR DESCRIPTION
Adding the same functionality as in IFTTT has for crating and updating thermostat settings.

This will add a new action card with inparameters "name", "target_temp", "measured_temp" and "climate_system"
The POST call for thermostats use a thermostate ID which we generate in hashString() from the inparameter "name".
Target temp and measured temp by range with possibility to use tags.
"climate systems", available options collected from getSystemCategories.